### PR TITLE
Важные улучшения

### DIFF
--- a/install.xml
+++ b/install.xml
@@ -1,7 +1,7 @@
 <modification>
   <name>Модульбанк: Интернет-Эквайринг</name>
   <code>modulbank_payment</code>
-  <version>1.5.0</version>
+  <version>1.5.1</version>
   <author>АО КБ «Модульбанк»</author>
   <link>https://modulbank.ru</link>
   <file path="catalog/model/checkout/order.php">

--- a/upload/catalog/model/payment/modulbank.php
+++ b/upload/catalog/model/payment/modulbank.php
@@ -5,6 +5,7 @@ include_once DIR_APPLICATION . 'controller/payment/modulbanklib/ModulbankReceipt
 
 class ModelPaymentModulbank extends Model {
 
+	const MAX_NAME_LENGTH = 128;
 	public function getMethod($address, $total) {
 		$this->load->language('payment/modulbank');
 
@@ -27,6 +28,7 @@ class ModelPaymentModulbank extends Model {
 			$method_data = array(
 				'code'       => 'modulbank',
 				'title'      => $this->config->get('modulbank_paymentname'),
+        		'title_adv'      => $this->language->get('text_title_adv'),
 				'terms'      => '',
 				'sort_order' => $this->config->get('modulbank_sort_order')
 			);
@@ -133,14 +135,23 @@ class ModelPaymentModulbank extends Model {
 			} else {
 				$item_vat = $product_vat;
 			}
-			$name = htmlspecialchars_decode($product['name']);
 
+			$name = $product['name'];
+
+			$name = htmlspecialchars_decode($name);
+			$name = mb_substr($name,0,self::MAX_NAME_LENGTH);
 
 			$RawItemsObject->addItem($name, $product['price'], $item_vat, $payment_object, $product['quantity']);
 		}
 		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "order_voucher WHERE order_id = '" . (int)$order_id . "'");
 		foreach ($query->rows as $product) {
-			$RawItemsObject->addItem($product['description'], $product['amount'], $voucher_vat, $payment_object_voucher);
+
+			$descr = $product['description'];
+
+			$descr = htmlspecialchars_decode($descr);
+			$descr = mb_substr($descr,0,self::MAX_NAME_LENGTH);
+
+			$RawItemsObject->addItem($descr, $product['amount'], $voucher_vat, $payment_object_voucher);
 		}
 		$query = $this->db->query("SELECT value FROM " . DB_PREFIX . "order_total WHERE order_id = '" . $order_id . "' and code='shipping'");
 		if (isset($query->row['value']) && $query->row['value']) {

--- a/upload/catalog/model/payment/modulbank.php
+++ b/upload/catalog/model/payment/modulbank.php
@@ -5,6 +5,8 @@ include_once DIR_APPLICATION . 'controller/payment/modulbanklib/ModulbankReceipt
 
 class ModelPaymentModulbank extends Model {
 
+	const MAX_NAME_LENGTH=128;
+	
 	public function getMethod($address, $total) {
 		$this->load->language('payment/modulbank');
 

--- a/upload/catalog/model/payment/modulbank.php
+++ b/upload/catalog/model/payment/modulbank.php
@@ -5,7 +5,6 @@ include_once DIR_APPLICATION . 'controller/payment/modulbanklib/ModulbankReceipt
 
 class ModelPaymentModulbank extends Model {
 
-	const MAX_NAME_LENGTH = 128;
 	public function getMethod($address, $total) {
 		$this->load->language('payment/modulbank');
 
@@ -136,7 +135,27 @@ class ModelPaymentModulbank extends Model {
 				$item_vat = $product_vat;
 			}
 
-			$name = $product['name'];
+			$option_data2=array();
+					
+			$order_option_query = $this->db->query("SELECT * FROM " . DB_PREFIX . "order_option WHERE order_id = '" . (int)$order_id . "' AND order_product_id = '" . (int)$product['order_product_id'] . "'");
+			
+			foreach ($order_option_query->rows as $option) {
+				if ($option['type'] != 'file') {
+					$value = $option['value'];
+				} else {
+					$value = utf8_substr($option['value'], 0, utf8_strrpos($option['value'], '.'));
+				}
+				
+				
+				$option_data2[]=$value;
+			}
+
+			$options_text=implode(';',$option_data2);
+
+			$name=$product['name'];
+
+			if (!empty($options_text))
+				$name.="(".$options_text.")";
 
 			$name = htmlspecialchars_decode($name);
 			$name = mb_substr($name,0,self::MAX_NAME_LENGTH);


### PR DESCRIPTION
1. Рефакторинг  catalog\controller\payment\modulbanklib\ModulbankReceipt.php
Непосредственно на функциональность модуля приёма платежей никак не влияет, но старый стиль написания модуля создавал угрозу неправильного использования, если программист решит внести изменения. А именно, повторный вызов ModulbankReceipt->getJson() портил данные внутри класса, и приводил к ошибке на странице оплаты. Исправлено путём разделения на два класса, ModulbankReceiptRawItems - список товаров, ModulbankReceipt - преобразование данных из списка товаров в нужную форму, и формирование json. Преобразование производится только в конструкторе, таким образом исключена ситуация когда данные могут быть преобразованы повторно и испорчены.
2. Ввёл обрезку названий товаров до максимально допустимой длины 128 символов. Без этого на товарах с длинными именами получал ошибку на странице оплаты.
3. Добавил вывод в чек выбранных опций товара (размер, цвет и др.) после имени товара. 